### PR TITLE
Take into account acknoledgeTransaction result

### DIFF
--- a/libwebpay/lib/webpaymallnormal.rb
+++ b/libwebpay/lib/webpaymallnormal.rb
@@ -183,7 +183,11 @@ class WebpayMallNormal
     }
 
     #Realizar el acknowledge
-    acknowledgeTransaction(token)
+    acknoledge_result = acknowledgeTransaction(token)
+
+    unless acknoledge_result['error_desc'] == 'TRX_OK'
+      response_array['error_desc'] = acknoledge_result['error_desc']
+    end
 
     return response_array
   end


### PR DESCRIPTION
- If acknoledgeTransaction call fails, getTransactionResult should
also fail. Otherwise the transaction will be reversed by Webpay and
it will still be seen as valid by the method consumer